### PR TITLE
HtmlEncoder was not encoding all utf-8 chars

### DIFF
--- a/OneTimeSharp/OtsConnector.cs
+++ b/OneTimeSharp/OtsConnector.cs
@@ -385,7 +385,7 @@ namespace VStepanov.OneTimeSharp
             {
                 postData +=
                     HttpUtility.HtmlEncode(pair.Key) + "=" +
-                    HttpUtility.HtmlEncode(pair.Value) + "&";
+                    HttpUtility.UrlEncode(pair.Value) + "&";
             }
 
             return Encoding.UTF8.GetBytes(postData);


### PR DESCRIPTION
special characters such as "æ" and "ð" were not being encoded correctly by HtmlEncode